### PR TITLE
Fix Glyphs Sometimes Existing Where They Shouldn't in Multiplayer

### DIFF
--- a/GlobalClasses/Items/GlyphGlobalItem.cs
+++ b/GlobalClasses/Items/GlyphGlobalItem.cs
@@ -28,7 +28,7 @@ namespace SpiritMod.GlobalClasses.Items
 
 		protected override bool CloneNewInstances => true;
 
-		public override bool AppliesToEntity(Item item, bool lateInstantiation) => item.maxStack == 1;
+		public override bool AppliesToEntity(Item item, bool lateInstantiation) => lateInstantiation && item.maxStack == 1;
 
 		public void SetGlyph(Item item, GlyphType glyph)
 		{

--- a/GlobalClasses/Players/GlyphPlayer.cs
+++ b/GlobalClasses/Players/GlyphPlayer.cs
@@ -50,8 +50,8 @@ namespace SpiritMod.GlobalClasses.Players
 					} //Chaos glyph effect
 
 					Glyph = glyphItem.Glyph;
-					if (Glyph == GlyphType.None && Player.nonTorch >= 0 && Player.nonTorch != Player.selectedItem && !Player.inventory[Player.nonTorch].IsAir)
-						Glyph = Player.inventory[Player.nonTorch].GetGlobalItem<GlyphGlobalItem>().Glyph;
+					if (Glyph == GlyphType.None && Player.nonTorch >= 0 && Player.nonTorch != Player.selectedItem && !Player.inventory[Player.nonTorch].IsAir && Player.inventory[Player.nonTorch].TryGetGlobalItem(out GlyphGlobalItem nonTorchGlyphItem))
+						Glyph = nonTorchGlyphItem.Glyph;
 				}
 				else Glyph = GlyphType.None;
 


### PR DESCRIPTION
Fixes an issue where, sometimes in multiplayer, glyphs would randomly be applied to items that really shouldn't have glyphs. This is complemented by the server and client seeming to disagree which items should(n't) have glyphs, leading to random glyph'd items at best and completely breaking multiplayer at worst.
Also fixed a small issue where `GlyphGlobalItem` was retrieved from an item without checking if that item actually had `GlyphGlobalItem`.

I'm not 100% sure of the cause of this, but I do know that I saw `GlyphGlobalItem` hooks being called on items that they shouldn't've been (namely, dyes). I want to say that it was being applied to modded items

**Reproduction**:
1. Enable Spirit Mod, any mod that adds a dye, and your cheat tool of choice. (I used Example Mod for this, but I can confirm it also happens with Calamity's Vanities).
2. Enter a world in singleplayer and place down a Mannequin. Fill this Mannequin's dye slots with a modded dye (Example Dye).
3. Place a second Mannequin to the right of the first one.
4. Exit the world, then Host & Play on the same world.
5. Upon loading in, the second Mannequin shouldn't be rendering properly, and other strange occurrences will be happening (tiles not being frames, chunk errors, NPCs sliding, etc.)