### PR TITLE
Content Definition helper

### DIFF
--- a/Items/Armor/WayfarerSet/WayfarerHead.cs
+++ b/Items/Armor/WayfarerSet/WayfarerHead.cs
@@ -46,7 +46,7 @@ namespace SpiritMod.Items.Armor.WayfarerSet
 		public static Condition QuestCondition() => new(Language.GetText("Mods.SpiritMod.Quests.RecipeConditions.DurasilkSheaf"), () =>
 		{
 			Quest quest = QuestManager.GetQuest<FirstAdventure>();
-			return quest.IsCompleted || quest.CurrentTask is ParallelTask || (quest.CurrentTask is RetrievalTask task && task.GetItemID() != ModContent.ItemType<Consumable.Quest.DurasilkSheaf>());
+			return quest.IsCompleted || quest.CurrentTask is ParallelTask || (quest.CurrentTask is RetrievalTask task && task.ItemType != ModContent.ItemType<Consumable.Quest.DurasilkSheaf>());
 		});
 	}
 }

--- a/Items/Consumable/Quest/ScientistLure.cs
+++ b/Items/Consumable/Quest/ScientistLure.cs
@@ -57,7 +57,7 @@ namespace SpiritMod.Items.Consumable.Quest
 		public static Condition QuestCondition() => new Condition(Language.GetText("Mods.SpiritMod.Quests.RecipeConditions.WarlockLure"), () =>
 		{
 			Mechanics.QuestSystem.Quest quest = QuestManager.GetQuest<ZombieOriginQuest>();
-			return (quest.CurrentTask is RetrievalTask task && task.GetItemID() == ModContent.ItemType<ScientistLure>());
+			return quest.CurrentTask is RetrievalTask task && task.ItemType == ModContent.ItemType<ScientistLure>();
 		});
 	}
 }

--- a/Items/Consumable/Quest/WarlockLure.cs
+++ b/Items/Consumable/Quest/WarlockLure.cs
@@ -60,7 +60,7 @@ namespace SpiritMod.Items.Consumable.Quest
 		public static Condition QuestCondition(int type) => new(Language.GetText("Mods.SpiritMod.Quests.RecipeConditions.WarlockLure"), () =>
 		{
 			Mechanics.QuestSystem.Quest quest = QuestManager.GetQuest<ZombieOriginQuest>();
-			return (quest.CurrentTask is RetrievalTask task && task.GetItemID() == type);
+			return quest.CurrentTask is RetrievalTask task && task.ItemType == type;
 		});
 	}
 

--- a/Mechanics/QuestSystem/Quest.cs
+++ b/Mechanics/QuestSystem/Quest.cs
@@ -13,6 +13,7 @@ using Terraria.Localization;
 using SpiritMod.NPCs.Town;
 using System.Linq;
 using Terraria.Chat;
+using SpiritMod.Utilities;
 
 namespace SpiritMod.Mechanics.QuestSystem
 {
@@ -164,13 +165,7 @@ namespace SpiritMod.Mechanics.QuestSystem
 			_currentTask.Activate(this);
 		}
 
-		public virtual void OnDeactivate()
-		{
-			if (_currentTask != null)
-			{
-				_currentTask.Deactivate();
-			}
-		}
+		public virtual void OnDeactivate() => _currentTask?.Deactivate();
 
 		public virtual void ResetEverything()
 		{
@@ -184,9 +179,7 @@ namespace SpiritMod.Mechanics.QuestSystem
 		public virtual void ResetAllProgress()
 		{
 			for (QuestTask task = _tasks.Start; task != null; task = task.NextTask)
-			{
 				task.ResetProgress();
-			}
 		}
 
 		public virtual void UpdateBookOverlay(UIShaderImage image) => image.Texture = null;
@@ -267,9 +260,7 @@ namespace SpiritMod.Mechanics.QuestSystem
 		public virtual void OnMPSync()
 		{
 			for (QuestTask task = _tasks.Start; task != null; task = task.NextTask)
-			{
 				task.OnMPSyncTick();
-			}
 		}
 
 		public virtual byte[] GetTaskDataBuffer()
@@ -277,28 +268,22 @@ namespace SpiritMod.Mechanics.QuestSystem
 			byte[] buffer = new byte[16];
 			using (var stream = new MemoryStream(buffer))
 			{
-				using (var writer = new BinaryWriter(stream))
-				{
-					writer.Write(_currentTask.TaskID);
-					_currentTask.WriteData(writer);
-				}
+				using var writer = new BinaryWriter(stream);
+				writer.Write(_currentTask.TaskID);
+				_currentTask.WriteData(writer);
 			}
 			return buffer;
 		}
 
 		public virtual void ReadFromDataBuffer(byte[] buffer)
 		{
-			using (var stream = new MemoryStream(buffer))
-			{
-				using (var reader = new BinaryReader(stream))
-				{
-					int taskId = reader.ReadInt32();
+			using var stream = new MemoryStream(buffer);
+			using var reader = new BinaryReader(stream);
+			int taskId = reader.ReadInt32();
 
-					_currentTask = _tasks[taskId];
-					_currentTask.ReadData(reader);
-					_currentTask.Activate(this); //Fixes branch quests being poorly reloaded
-				}
-			}
+			_currentTask = _tasks[taskId];
+			_currentTask.ReadData(reader);
+			_currentTask.Activate(this); //Fixes branch quests being poorly reloaded
 		}
 
 		public void GiveRewards()
@@ -307,12 +292,12 @@ namespace SpiritMod.Mechanics.QuestSystem
 				return;
 
 			foreach (var itemPair in QuestRewards)
-				ItemUtils.NewItemWithSync(Main.LocalPlayer.GetSource_GiftOrReward(), Main.myPlayer, Main.LocalPlayer.getRect(), itemPair.Item1, itemPair.Item2);
+				ItemUtils.NewItemWithSync(Main.LocalPlayer.GetSource_GiftOrReward(), Main.myPlayer, Main.LocalPlayer.getRect(), ContentDefinition.GetItemDefinition(itemPair.Item1), itemPair.Item2);
 		}
 
-		public void ModifySpawnRateUnique(IDictionary<int, float> pool, int id, float rate)
+		public static void ModifySpawnRateUnique(IDictionary<int, float> pool, int id, float rate)
 		{
-			if (pool.ContainsKey(id) && pool[id] > 0f && !NPC.AnyNPCs(id))
+			if (pool.TryGetValue(id, out float value) && value > 0f && !NPC.AnyNPCs(id))
 				pool[id] = rate;
 		}
 

--- a/Mechanics/QuestSystem/QuestManager.cs
+++ b/Mechanics/QuestSystem/QuestManager.cs
@@ -37,13 +37,13 @@ public static class QuestManager
 
 	public static void Load()
 	{
-		_questDict = new Dictionary<Type, Quest>();
-		_tasksDict = new Dictionary<string, QuestTask>();
-		Categories = new Dictionary<string, QuestCategory>();
+		_questDict = [];
+		_tasksDict = [];
+		Categories = [];
 
-		Quests = new List<Quest>();
-		ActiveQuests = new List<Quest>();
-		UnloadedQuests = new Dictionary<string, StoredQuestData>();
+		Quests = [];
+		ActiveQuests = [];
+		UnloadedQuests = [];
 
 		// register our categories]
 		if (!Main.dedServ)

--- a/Mechanics/QuestSystem/Quests/AnglerStatueQuest.cs
+++ b/Mechanics/QuestSystem/Quests/AnglerStatueQuest.cs
@@ -4,39 +4,38 @@ using SpiritMod.Mechanics.QuestSystem.Tasks;
 using SpiritMod.Items.Placeable.Furniture;
 using Terraria.Localization;
 
-namespace SpiritMod.Mechanics.QuestSystem.Quests
+namespace SpiritMod.Mechanics.QuestSystem.Quests;
+
+public class AnglerStatueQuest : Quest
 {
-    public class AnglerStatueQuest : Quest
-    {
-		public override int Difficulty => 1;
-		public override string QuestCategory => "Forager";
+	public override int Difficulty => 1;
+	public override string QuestCategory => "Forager";
 
-		public override (int, int)[] QuestRewards => _rewards;
-		private readonly (int, int)[] _rewards = new[]
-		{
-			(ItemID.GoldCoin, 3),
-			(ItemID.MasterBait, 3),
-			(ModContent.ItemType<Items.Fishing.FisheyeGem>(), 1)
-		};
+	public override (int, int)[] QuestRewards => _rewards;
+	private readonly (int, int)[] _rewards =
+	[
+		(ItemID.GoldCoin, 3),
+		(ItemID.MasterBait, 3),
+		(ModContent.ItemType<Items.Fishing.FisheyeGem>(), 1)
+	];
 
-		private AnglerStatueQuest()
-        {
-			TaskBuilder branch1 = new TaskBuilder();
-			branch1.AddTask(new RetrievalTask(ItemID.RedSnapper, 3424, GetText("AppeaseLine")))
-			       .AddTask(new GiveNPCTask(NPCID.Angler, ItemID.RedSnapper, 3424, LocalizedText.Empty, GetText("GiveToAngler"), true, true));
-		
-			TaskBuilder branch2 = new TaskBuilder();
-			branch2.AddTask(new TalkNPCTask(NPCID.Guide, GetText("GuideCheckin"), GetText("AskGuide")))
-				   .AddTask(new TalkNPCTask(NPCID.Angler, GetText("AnglerStatueDemand"), GetText("TalkLine")))
-				   .AddTask(new RetrievalTask(ModContent.ItemType<GiantAnglerStatue>(), 1))
-				   .AddTask(new GiveNPCTask(NPCID.Angler, ModContent.ItemType<GiantAnglerStatue>(), 1, GetText("CheerUp"), GetText("ShowAnglerCreation"), true, false, ItemID.FishermansGuide));
+	private AnglerStatueQuest()
+	{
+		TaskBuilder branch1 = new TaskBuilder();
+		branch1.AddTask(new RetrievalTask(ItemID.RedSnapper, 3424, GetText("AppeaseLine")))
+			   .AddTask(new GiveNPCTask(NPCID.Angler, ItemID.RedSnapper, 3424, LocalizedText.Empty, GetText("GiveToAngler"), true, true));
 
-			TaskBuilder branch3 = new TaskBuilder();
+		TaskBuilder branch2 = new TaskBuilder();
+		branch2.AddTask(new TalkNPCTask(NPCID.Guide, GetText("GuideCheckin"), GetText("AskGuide")))
+			   .AddTask(new TalkNPCTask(NPCID.Angler, GetText("AnglerStatueDemand"), GetText("TalkLine")))
+			   .AddTask(new RetrievalTask(ModContent.ItemType<GiantAnglerStatue>(), 1))
+			   .AddTask(new GiveNPCTask(NPCID.Angler, ModContent.ItemType<GiantAnglerStatue>(), 1, GetText("CheerUp"), GetText("ShowAnglerCreation"), true, false, ItemID.FishermansGuide));
+
+		TaskBuilder branch3 = new TaskBuilder();
 			branch3.AddTask(new RetrievalTask(ModContent.ItemType<Items.Placeable.FishCrate>(), 3))
 			      .AddTask(new GiveNPCTask(NPCID.Angler, ModContent.ItemType<Items.Placeable.FishCrate>(), 3, GetText("Defeated"), GetText("ShowAnglerCrates"), true, false))
-				  .AddBranches(branch1, branch2);
+			  .AddBranches(branch1, branch2);
 
-			_tasks.AddBranches(branch3);
-		}
+		_tasks.AddBranches(branch3);
 	}
 }

--- a/Mechanics/QuestSystem/Tasks/RetrievalTask.cs
+++ b/Mechanics/QuestSystem/Tasks/RetrievalTask.cs
@@ -1,32 +1,15 @@
 ﻿using SpiritMod.Utilities;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
 using Terraria;
 using Terraria.ID;
 using Terraria.Localization;
-using Terraria.ModLoader;
 
 namespace SpiritMod.Mechanics.QuestSystem.Tasks
 {
 	public class RetrievalTask : QuestTask
 	{
 		public override string ModCallName => "Retrieve";
-
-		/// <summary>
-		/// Lazy hardcoded check for Spirit Reforged compatibility.<br/>
-		/// Just replaces the fish crate ID with Reforged's fish crate ID.
-		/// </summary>
-		private int ActualItemId
-		{
-			get
-			{
-				if (_itemID == ModContent.ItemType<Items.Placeable.FishCrate>() && ModLoader.TryGetMod("SpiritReforged", out var reforged))
-					return reforged.Find<ModItem>("FishCrate").Type;
-
-				return _itemID;
-			}
-		}
 
 		private readonly int _itemID;
 		private readonly int _itemsNeeded;
@@ -92,7 +75,7 @@ namespace SpiritMod.Mechanics.QuestSystem.Tasks
 				return builder.ToString();
 			}
 
-			string itemName = Lang.GetItemNameValue(ActualItemId);
+			string itemName = Lang.GetItemNameValue(ItemType);
 			string count = _itemsNeeded > 1 ? _itemsNeeded.ToString() : "1";
 			builder.Append(_wording).Append(' ').Append(count).Append(' ').Append(itemName);
 
@@ -113,7 +96,7 @@ namespace SpiritMod.Mechanics.QuestSystem.Tasks
 		{
 			if (Main.netMode == NetmodeID.SinglePlayer)
 			{
-				_lastCount = Main.LocalPlayer.CountItem(ActualItemId, _itemsNeeded);
+				_lastCount = Main.LocalPlayer.CountItem(ItemType, _itemsNeeded);
 				return _lastCount >= _itemsNeeded;
 			}
 			else if (Main.netMode == NetmodeID.MultiplayerClient)
@@ -123,12 +106,12 @@ namespace SpiritMod.Mechanics.QuestSystem.Tasks
 				{
 					Player p = Main.player[i];
 					if (p.active)
-						_lastCount += p.CountItem(ActualItemId, _itemsNeeded);
+						_lastCount += p.CountItem(ItemType, _itemsNeeded);
 				}
 			}
 			return _lastCount >= _itemsNeeded;
 		}
 
-		internal int GetItemID() => ActualItemId;
+		internal int ItemType => ContentDefinition.GetItemDefinition(_itemID);
 	}
 }

--- a/SpiritMod.Call.cs
+++ b/SpiritMod.Call.cs
@@ -6,6 +6,7 @@ using Terraria.ModLoader;
 using SpiritMod.Mechanics.QuestSystem;
 using SpiritMod.Mechanics.PortraitSystem;
 using SpiritMod.GlobalClasses.Items;
+using SpiritMod.Utilities;
 
 namespace SpiritMod;
 
@@ -75,6 +76,11 @@ public partial class SpiritMod : Mod
 			}
 			else if (context == CallContext.Events) //Gets or sets event bools
 				return EventCall(args);
+			else if (context == CallContext.AddItemDefinition)
+			{
+				if (args[1] is int from && args[2] is int to)
+					ContentDefinition.ItemDefinitions.Add(from, to);
+			}
 		}
 		catch (Exception e)
 		{
@@ -180,6 +186,7 @@ public partial class SpiritMod : Mod
 			"IsQuestCompleted" => CallContext.GetQuestIsCompleted,
 			"QuestRewardsGiven" => CallContext.GetQuestRewardsGiven,
 			"Portrait" => CallContext.Portrait,
+			"AddItemDefinition" => CallContext.AddItemDefinition,
 			_ => CallContext.Invalid,
 		};
 	}
@@ -247,5 +254,6 @@ internal enum CallContext
 	GetQuestRewardsGiven,
 	Portrait,
 	Events,
+	AddItemDefinition,
 	Limit
 }

--- a/UI/QuestUI/QuestBookUI.cs
+++ b/UI/QuestUI/QuestBookUI.cs
@@ -598,12 +598,12 @@ namespace SpiritMod.UI.QuestUI
 			{
 				foreach (var reward in quest.QuestRewards)
 				{
-					_questRewardList.Add(new UIRewardItem(reward.Item1, reward.Item2));
+					_questRewardList.Add(new UIRewardItem(ContentDefinition.GetItemDefinition(reward.Item1), reward.Item2));
 				}
 			}
 
 			// pick a "random" mask
-			int maskIndex = (quest.QuestName.Length * quest.QuestDescription.Length) % _imageMasks.Length;
+			int maskIndex = quest.QuestName.Length * quest.QuestDescription.Length % _imageMasks.Length;
 			_questImage.Effect.Parameters["AlphaMaskTexture"].SetValue(_imageMasks[maskIndex]);
 
 			SelectedQuest = quest;

--- a/Utilities/ContentDefinition.cs
+++ b/Utilities/ContentDefinition.cs
@@ -6,7 +6,7 @@ namespace SpiritMod.Utilities;
 /// <summary> Allows overriding various <see cref="ModType"/> definitions for cross-mod compatibility purposes. </summary>
 public static class ContentDefinition
 {
-	private static readonly Dictionary<int, int> ItemDefinitions = [];
+	public static readonly Dictionary<int, int> ItemDefinitions = [];
 
 	public static int ItemType<T>() where T : ModItem => GetItemDefinition(ModContent.GetInstance<T>()?.Type ?? 0);
 

--- a/Utilities/ContentDefinition.cs
+++ b/Utilities/ContentDefinition.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using Terraria.ModLoader;
+
+namespace SpiritMod.Utilities;
+
+/// <summary> Allows overriding various <see cref="ModType"/> definitions for cross-mod compatibility purposes. </summary>
+public static class ContentDefinition
+{
+	private static readonly Dictionary<int, int> ItemDefinitions = [];
+
+	public static int ItemType<T>() where T : ModItem => GetItemDefinition(ModContent.GetInstance<T>()?.Type ?? 0);
+
+	/// <summary> Gets the variable definition of the given item type. </summary>
+	public static int GetItemDefinition(int ofType)
+	{
+		if (ItemDefinitions.TryGetValue(ofType, out int newType))
+			return newType;
+
+		return ofType;
+	}
+}


### PR DESCRIPTION
Adds helper `ContentDefinition` for external control over item types bound to quests. Removes the recent Packing Crate bandaid fix for being obsolete.