### PR TITLE
Fix hardcoded English pluralization in glyph/token price text

### DIFF
--- a/Items/Glyphs/GlyphBase.cs
+++ b/Items/Glyphs/GlyphBase.cs
@@ -97,6 +97,6 @@ namespace SpiritMod.Items.Glyphs
 
 		public int SellType() => ModContent.ItemType<Glyph>();
 
-		public string SellName() => "glyph";
+		public string SellNameKey() => "Mods.SpiritMod.Items.Glyph.PriceText";
 	}
 }

--- a/Items/Sets/OlympiumSet/OlympiumCurrency.cs
+++ b/Items/Sets/OlympiumSet/OlympiumCurrency.cs
@@ -14,16 +14,13 @@ namespace SpiritMod.Items.Sets.OlympiumSet
 		public override void GetPriceText(string[] lines, ref int currentLine, long price)
 		{
 			Color color = Color.Gold * (Main.mouseTextColor / 255f);
-			string tokenName = Language.GetTextValue("Mods.SpiritMod.Items.OlympiumToken.DisplayName");
-			string plural = price > 1 ? Language.GetTextValue("Mods.SpiritMod.Misc.PluralSuffix") : "";
 
-			lines[currentLine++] = string.Format("[c/{0:X2}{1:X2}{2:X2}:{3} {4} {5}]",
+			lines[currentLine++] = string.Format("[c/{0:X2}{1:X2}{2:X2}:{3} {4}]",
 					color.R,
 					color.G,
 					color.B,
 					Language.GetTextValue("LegacyTooltip.50"),
-					price,
-					tokenName + plural
+					Language.GetText("Mods.SpiritMod.Items.OlympiumToken.PriceText").Format(price)
 				);
 		}
 	}

--- a/Localization/en-US/Mods.SpiritMod.Items.hjson
+++ b/Localization/en-US/Mods.SpiritMod.Items.hjson
@@ -3762,6 +3762,7 @@ Glyph: {
 	Target: Can only be applied to weapons
 	RightClick: Hold this glyph and right-click the weapon you want to enchant
 	Remove: Hold this glyph and right-click the item whose glyph you want to remove
+	PriceText: "{0} {^0:glyph;glyphs}"
 }
 
 NullGlyph: {
@@ -7395,6 +7396,7 @@ MarkOfZeus: {
 OlympiumToken: {
 	DisplayName: Olympium Token
 	Tooltip: May be of interest to a collector...
+	PriceText: "{0} {^0:Olympium Token;Olympium Tokens}"
 }
 
 DuelistLegacy: {

--- a/Localization/zh-Hans/Mods.SpiritMod.Items.hjson
+++ b/Localization/zh-Hans/Mods.SpiritMod.Items.hjson
@@ -3762,6 +3762,7 @@ Glyph: {
 	Target: 只能附魔于武器上
 	RightClick: 手持此雕文并右键你想要附魔的武器
 	Remove: 手持此雕文并右键你想要移除附魔的物品
+	PriceText: "{0} 雕文" # @Lin please check if this translation is OK
 }
 
 NullGlyph: {
@@ -7395,6 +7396,7 @@ MarkOfZeus: {
 OlympiumToken: {
 	DisplayName: 奥林匹克代币
 	Tooltip: 可能会引起收藏家的兴趣……
+	PriceText: "{0} 奥林匹克代币"
 }
 
 DuelistLegacy: {

--- a/Mechanics/SpecialSellItem/SpecialSellItem.cs
+++ b/Mechanics/SpecialSellItem/SpecialSellItem.cs
@@ -22,10 +22,12 @@ namespace SpiritMod.Mechanics.SpecialSellItem
 				var specialSell = item.ModItem as ISpecialSellItem;
 
 				int customPrice = specialSell.SellAmount();
-				ModItem currencyItem = ItemLoader.GetItem(specialSell.SellType());
-				string name = (specialSell.SellName() == string.Empty) ? currencyItem.DisplayName.Value : (item.ModItem as ISpecialSellItem).SellName();
+				string nameKey = specialSell.SellNameKey();
+				string priceText = (nameKey == string.Empty)
+					? $"{customPrice} {ItemLoader.GetItem(specialSell.SellType()).DisplayName.Value}"
+					: Language.GetText(nameKey).Format(customPrice);
 
-				priceLine.Text = $"{Language.GetTextValue("LegacyTooltip.49")} {customPrice} " + name + ((customPrice > 1) ? Language.GetTextValue("Mods.SpiritMod.Misc.PluralSuffix") : string.Empty);
+				priceLine.Text = $"{Language.GetTextValue("LegacyTooltip.49")} {priceText}";
 				priceLine.OverrideColor = specialSell.SellColor();
 			}
 		}
@@ -76,7 +78,8 @@ namespace SpiritMod.Mechanics.SpecialSellItem
 
 		int SellAmount() => 1;
 
-		string SellName() => string.Empty;
+		/// <summary> Localization key for the pluralizable sell amount text (e.g. "5 glyphs"), formatted via <see cref="LocalizedText.Format"/> with the sell amount as arg 0. Empty to fall back to the currency item's display name. </summary>
+		string SellNameKey() => string.Empty;
 
 		Color SellColor() => Color.Orange;
 	}

--- a/Utilities/Currency.cs
+++ b/Utilities/Currency.cs
@@ -12,13 +12,12 @@ namespace SpiritMod.Utilities
 		public override void GetPriceText(string[] lines, ref int currentLine, long price)
 		{
 			Color glyphColor = Color.Orange * (Main.mouseTextColor / 255f);
-			lines[currentLine++] = string.Format("[c/{0:X2}{1:X2}{2:X2}:{3} {4} {5}]",
+			lines[currentLine++] = string.Format("[c/{0:X2}{1:X2}{2:X2}:{3} {4}]",
 					glyphColor.R,
 					glyphColor.G,
 					glyphColor.B,
 					Language.GetTextValue("LegacyTooltip.50"),
-					price,
-					price > 1 ? "glyphs" : "glyph"
+					Language.GetText("Mods.SpiritMod.Items.Glyph.PriceText").Format(price)
 				);
 		}
 	}


### PR DESCRIPTION
This is a follow up to 999c8d95, which fixed two of the same category bugs (QuestBookUI.SelectQuest, buff ModifyBuffText) but left a group of untouched ones:

- `Utilities/Currency.cs` (GlyphCurrency.GetPriceText) is never touched, still hardcodes `"glyph"` and `"glyphs"` as raw English literals.
- `Items/Glyphs/GlyphBase.cs` (SellName) same hardcoded noun
- `Items/Sets/OlympiumSet/OlympiumCurrency.cs` (GetPriceText) is changed by 999c8d95, but only replaced `+ "s"` with `+ Language.GetTextValue("Mods.SpiritMod.Misc.PluralSuffix")`, which still assumes pluralization = appending a suffix to the end of the whole phrase. This could not be correct at all for any language that pluralizes the noun itself rather than the trailing word (e.g. Spanish's "Ficha de Olimpium" => "Fichas de Olimpium", not "Ficha de Olimpiums", which sounds weird for a native Spanish speaker).
- `Mechanics/SpecialSellItem/SpecialSellItem.cs` (ModifyTooltips) same broken pattern, same `PluralSuffix` key.

## Fix proposed
Use tML's built-in pluralization support (`LocalizedText.Format` + the `{^0:singular;plural}` syntax), the same mechanism vanilla Terraria uses, instead of manual string concatenation.
- Added `Mods.SpiritMod.Items.Glyph.PriceText` and `Mods.SpiritMod.Items.OlympiumToken.PriceText` in `en-US` & `zh-Hans` (note: I'm not sure at all if my zh-Hans translation is ok, that would need to be checked by the chinese translator)
- `Currency.cs` and `OlympiumCurrency.cs` replaced manual `price > 1 ? …` ternaries with `Language.GetText(key).Format(price)`.
- `ISpecialSellItem.SellName()` refactored to `SellNameKey()`. Now returns a localization key (used with `.Format(sellAmount)`) instead of an already-resolved literal, so `SpecialSellItem.ModifyTooltips` can pluralize correctly regardless of language. I checked all possible implementations and only refactored `GlyphBase`, which is the only one.

I tested my implementation using `en-US`, `zh-Hans` and `es-ES` languages, did not find any problems with it. That being said, it should probably be verified by someone else as well just in case.